### PR TITLE
Framework localization fix

### DIFF
--- a/QBValidator/QBValidator.m
+++ b/QBValidator/QBValidator.m
@@ -186,7 +186,13 @@
             }
             key = [key stringByAppendingString:@"Satisfied"];
             
-            NSString *errorMessage = NSLocalizedStringFromTable(key, [rule localizationTableName], nil);
+            // First check bundleForClass:
+            // This will ensure that we work if packaged in a framework
+            NSString *errorMessage = NSLocalizedStringFromTableInBundle(key, [rule localizationTableName], [NSBundle bundleForClass:[self class]], nil);
+            if ([errorMessage isEqualToString:key]) {
+                // Fall back to main bundle
+                errorMessage = NSLocalizedStringFromTableInBundle(key, [rule localizationTableName], [NSBundle mainBundle], nil);
+            }
             
             // Replace patterns
             errorMessage = [errorMessage stringByReplacingOccurrencesOfString:@"{name}"


### PR DESCRIPTION
Previously QBValidator was using `NSLocalizedStringFromTable` to do localizations.   Which works in the case that you're not using QBValidator as a .framework.

The solution is to first try to `NSLocalizedStringFromTableInBundle` using `[NSBundle bundleForClass:[self class]]`.  This will get the key from the .framework bundle if available.   If not, then go to the main bundle
