### PR TITLE
Copy min/max Value properties

### DIFF
--- a/QBValidator/QBValidationRangeRule.h
+++ b/QBValidator/QBValidationRangeRule.h
@@ -10,8 +10,8 @@
 
 @interface QBValidationRangeRule : QBValidationRule
 
-@property (nonatomic, assign, readonly) NSNumber *minValue;
-@property (nonatomic, assign, readonly) NSNumber *maxValue;
+@property (nonatomic, copy, readonly) NSNumber *minValue;
+@property (nonatomic, copy, readonly) NSNumber *maxValue;
 @property (nonatomic, assign, readonly) BOOL inclusive;
 
 + (instancetype)ruleWithMinValue:(NSNumber *)minValue maxValue:(NSNumber *)maxValue inclusive:(BOOL)inclusive;

--- a/QBValidator/QBValidationRangeRule.m
+++ b/QBValidator/QBValidationRangeRule.m
@@ -10,8 +10,8 @@
 
 @interface QBValidationRangeRule ()
 
-@property (nonatomic, assign, readwrite) NSNumber *minValue;
-@property (nonatomic, assign, readwrite) NSNumber *maxValue;
+@property (nonatomic, copy, readwrite) NSNumber *minValue;
+@property (nonatomic, copy, readwrite) NSNumber *maxValue;
 @property (nonatomic, assign, readwrite) BOOL inclusive;
 
 @end


### PR DESCRIPTION
Previously the minValue and maxValue properties on QBValidationRangeRule were set to assign.   Which meant that whoever created this rule was in charge of keeping reference to these objects until the rule finished running.

This practice is not consistent with the interface designed by QBValidator.   The use case is defined to use the macro functions as such

```
QBVLessThan(@(10))
QBVInRange(10, 20)
```

In the examples above, nobody is keeping hold of the `@(10)`.   So we basically enter into a race condition.   The device could reassign that pointer without our knowledge and cause a crash whenever the comparisons are made.

The fix is to simply copy these values, so the rule has a dedicated reference to the pointers that will be around for the lifetime of the rule.
